### PR TITLE
chore(image): use taro-image to avoid type error

### DIFF
--- a/src/components/My/index.vue
+++ b/src/components/My/index.vue
@@ -4,7 +4,7 @@
     <view class="flex-column">
       <card v-if="isActive" class="profile-card">
         <view class="avatar-wrapper">
-          <image
+          <taro-image
             v-if="wxProfile"
             class="avatar"
             :src="wxProfile.avatarUrl"
@@ -77,6 +77,7 @@ import "./index.scss";
 import { storeToRefs } from "pinia";
 import useNewFeatureStore from "@/store/service/newFeature";
 import useUserStore from "@/store/service/user";
+import { Image as TaroImage } from "@tarojs/components";
 
 const userStore = useUserStore();
 const newFeatureStore = useNewFeatureStore();

--- a/src/pages/about/index.vue
+++ b/src/pages/about/index.vue
@@ -4,9 +4,9 @@
     <scroll-view :scroll-y="true" style="flex: 1">
       <view class="flex-column">
         <card>
-          <image
+          <taro-image
             mode="aspectFit"
-            src="@/assets/jh-logo.png"
+            :src="JHLogo"
             style="height: 20vh; width: 70%; display: block; margin: auto"
           />
         </card>
@@ -34,8 +34,10 @@
 </template>
 
 <script setup lang="ts">
+import { Image as TaroImage } from "@tarojs/components";
 import { Card, ThemeConfig, TitleBar } from "@/components";
 import { aboutText } from "@/constants/copywriting";
+import JHLogo from "@/assets/jh-logo.png";
 import { getCopyRight } from "@/utils";
 import "./index.scss";
 

--- a/src/pages/announcement/InformationCard/index.vue
+++ b/src/pages/announcement/InformationCard/index.vue
@@ -5,6 +5,7 @@ import styles from "./index.module.scss";
 import { Card } from "@/components";
 import dayjs from "dayjs";
 import useWebview from "@/hooks/useWebview";
+import { Image as TaroImage } from "@tarojs/components";
 
 const { open } = useWebview();
 const props = defineProps<{
@@ -45,7 +46,7 @@ const timeFormat = (time: string) => {
     </view>
     <template #footer>
       <view :class="styles.logo_container">
-        <image
+        <taro-image
           src="https://api.cnpatrickstar.com/img/92a63e97-cd3e-411b-b4aa-8e6fad5fbd00.jpg"
           alt="logo_fy"
           :class="styles.logo_fy"
@@ -54,7 +55,7 @@ const timeFormat = (time: string) => {
         <view :class="styles.x">
           X
         </view>
-        <image
+        <taro-image
           src="https://api.cnpatrickstar.com/img/15c05a4c-7c2d-4561-9536-80614b7b65b8.jpg"
           alt="logo_jh"
           :class="styles.logo_jh"

--- a/src/pages/announcement/index.vue
+++ b/src/pages/announcement/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="公告" back-button />
     <scroll-view :scroll-y="true">
       <view class="header-view">
-        <image src="@/assets/photos/announcement.svg" />
+        <taro-image :src="AnnouncementCoverImage" />
       </view>
       <view class="tab-bar">
         <text
@@ -64,6 +64,8 @@ import { ref } from "vue";
 import Taro from "@tarojs/taro";
 import useNotificationStore from "@/store/service/notification";
 import { storeToRefs } from "pinia";
+import { Image as TaroImage } from "@tarojs/components";
+import AnnouncementCoverImage from "@/assets/photos/announcement.svg";
 
 const { announcement, information } = storeToRefs(useNotificationStore());
 // 根据路由导航

--- a/src/pages/bind/YXY/index.vue
+++ b/src/pages/bind/YXY/index.vue
@@ -9,6 +9,7 @@ import { RequestError } from "@/utils";
 import useUserStore from "@/store/service/user";
 import useHomeCardStore from "@/store/service/homecard";
 import useWebview from "@/hooks/useWebview";
+import { Image as TaroImage } from "@tarojs/components";
 
 const { updateBindState } = useUserStore();
 const homeCardStore = useHomeCardStore();
@@ -127,7 +128,7 @@ onMounted(() => {
       >
         点击重试
       </view>
-      <image
+      <taro-image
         v-else-if="imageResponse"
         :src="imageResponse.replace(/[\r\n]/g, '')"
         style="width: 160rpx; height: 60rpx"

--- a/src/pages/connect/index.vue
+++ b/src/pages/connect/index.vue
@@ -9,8 +9,8 @@
           </template>
           <w-list inner>
             <w-list-item>
-              <image
-                src="@/assets/photos/feedback.svg"
+              <taro-image
+                :src="FeedbackCoverImage"
                 style="margin: 8px 0; width: 100%"
               />
             </w-list-item>
@@ -30,6 +30,8 @@
 <script setup lang="ts">
 import Taro from "@tarojs/taro";
 import { Card, ThemeConfig, TitleBar, WList, WListItem } from "@/components";
+import { Image as TaroImage } from "@tarojs/components";
+import FeedbackCoverImage from "@/assets/photos/feedback.svg";
 import "./index.scss";
 
 const groupInfo = [

--- a/src/pages/electricity/index.vue
+++ b/src/pages/electricity/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="寝室电费查询" back-button />
     <scroll-view :scroll-y="true">
       <view class="header-view">
-        <image src="@/assets/photos/electricity.svg" />
+        <taro-image :src="ElectricityCoverImage" />
       </view>
       <view class="flex-column">
         <card class="info-card">
@@ -88,6 +88,8 @@ import useElectricityBalanceStore from "@/store/service/balance";
 import { storeToRefs } from "pinia";
 import { useRequestNext } from "@/hooks";
 import { YxyService } from "@/services";
+import ElectricityCoverImage from "@/assets/photos/electricity.svg";
+import { Image as TaroImage } from "@tarojs/components";
 
 const { room, balance } = storeToRefs(useElectricityBalanceStore());
 const { loading: consumptionLoading, data: consumption } = useRequestNext(

--- a/src/pages/exam/index.vue
+++ b/src/pages/exam/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="考试安排" back-button />
     <scroll-view :scroll-y="true">
       <view class="header-view">
-        <image src="@/assets/photos/exam.svg" />
+        <taro-image :src="ExamCoverImage" />
         <view class="extra" @tap="showHelp">
           <view class="icon-wrapper">
             <view class="extra-icon iconfont icon-announcement" />
@@ -136,6 +136,8 @@ import {
 import { ZFService } from "@/services";
 import dayjs, { ConfigType } from "dayjs";
 import { helpText } from "@/constants/copywriting";
+import { Image as TaroImage } from "@tarojs/components";
+import ExamCoverImage from "@/assets/photos/exam.svg";
 import "./index.scss";
 
 const selectTerm = ref({

--- a/src/pages/lessonstable/index.vue
+++ b/src/pages/lessonstable/index.vue
@@ -40,11 +40,8 @@
       </view>
       <view class="col">
         <view class="switch-button" @tap="pickerModeSwitch">
-          <image
-            v-if="!showWeekPicker"
-            src="@/assets/icons/term-week-swicher/term.svg"
-          />
-          <image v-else src="@/assets/icons/term-week-swicher/week.svg" />
+          <taro-image v-if="!showWeekPicker" :src="TermSwitcherIcon" />
+          <taro-image v-else :src="WeekSwitcherIcon" />
         </view>
       </view>
     </bottom-panel>
@@ -87,6 +84,9 @@ import { useTimeInstance } from "@/hooks";
 import { storeToRefs } from "pinia";
 import useGeneralInfoStore from "@/store/system/generalInfo";
 import useLessonTableStore from "@/store/service/lessonTable";
+import TermSwitcherIcon from "@/assets/icons/term-week-swicher/term.svg";
+import WeekSwitcherIcon from "@/assets/icons/term-week-swicher/week.svg";
+import { Image as TaroImage } from "@tarojs/components";
 
 const showPop = ref(false);
 const selection = ref<Lesson>();

--- a/src/pages/library/index.vue
+++ b/src/pages/library/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="借阅信息" back-button />
     <scroll-view :scroll-y="true">
       <view class="header-view">
-        <image src="@/assets/photos/library.svg" />
+        <taro-image :src="LibraryCoverImage" />
         <view class="summary">
           <view>
             借阅：
@@ -94,6 +94,8 @@ import { LibraryService } from "@/services";
 import { BorrowBooksInfo } from "@/types/BorrowBooksInfo";
 import useLibraryStore from "@/store/service/library";
 import { useRequestNext } from "@/hooks";
+import { Image as TaroImage } from "@tarojs/components";
+import LibraryCoverImage from "@/assets/photos/library.svg";
 
 const libraryStore = useLibraryStore();
 const isSelectToday = ref(true);

--- a/src/pages/lostfound/PreviewCard/index.vue
+++ b/src/pages/lostfound/PreviewCard/index.vue
@@ -10,14 +10,14 @@
         {{ source.type ? "失物招领": "寻物启事" }}
       </view>
       <view v-if="isForyou" :class="styles.joint">
-        <image
+        <taro-image
           src="https://api.cnpatrickstar.com/img/92a63e97-cd3e-411b-b4aa-8e6fad5fbd00.jpg"
           alt="logo_fy"
           :class="styles.logo"
           mode="aspectFit"
         />
         <text>x</text>
-        <image
+        <taro-image
           src="https://api.cnpatrickstar.com/img/15c05a4c-7c2d-4561-9536-80614b7b65b8.jpg"
           alt="logo_jh"
           :class="styles.logo"
@@ -75,7 +75,7 @@
             :key="`${source.id}-${item}`"
             :class="styles['img-wrapper']"
           >
-            <image
+            <taro-image
               :class="styles.image"
               style="width: 100Px ;height: 100Px"
               mode="aspectFill"
@@ -137,7 +137,7 @@
             :key="`${source.id}-${item}`"
             :class="styles['img-wrapper']"
           >
-            <image
+            <taro-image
               :class="styles.image"
               style="width: 100Px ;height: 100Px"
               mode="aspectFill"
@@ -162,6 +162,7 @@ import { computed, ref, toRefs } from "vue";
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
 import styles from "./index.module.scss";
+import { Image as TaroImage } from "@tarojs/components";
 
 const props = defineProps<{
   source: LostfoundRecord;

--- a/src/pages/schoolcard/index.vue
+++ b/src/pages/schoolcard/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="校园卡" back-button />
     <scroll-view :scroll-y="true">
       <view class="school-card">
-        <image mode="aspectFit" src="@/assets/photos/card.svg" />
+        <taro-image mode="aspectFit" :src="SchoolCardCoverImage" />
         <text class="balance">
           ¥ {{ cardBalanceStore.balance }}
         </text>
@@ -74,11 +74,12 @@ import { Card, RefreshButton, ThemeConfig, TitleBar, WButton } from "@/component
 import dayjs from "dayjs";
 import "./index.scss";
 import { YxyService } from "@/services";
-import { Picker } from "@tarojs/components";
+import { Picker, Image as TaroImage } from "@tarojs/components";
 import Taro from "@tarojs/taro";
 import useCardBalanceStore from "@/store/service/cardBalance";
 import { RequestError } from "@/utils";
 import { useRequestNext } from "@/hooks";
+import SchoolCardCoverImage from "@/assets/photos/card.svg";
 
 const cardBalanceStore = useCardBalanceStore();
 const selectedDate = ref(dayjs().format("YYYY-MM-DD")); // YYYY-MM-DD

--- a/src/pages/setting/index.vue
+++ b/src/pages/setting/index.vue
@@ -38,20 +38,18 @@
         </card>
       </view>
     </scroll-view>
-    <image
-      v-if="isEmpty"
-      src="@/assets/photos/setting.svg"
-      style="margin: 0 auto"
-    />
+    <taro-image v-if="isEmpty" :src="SettingCoverImage" style="margin: 0 auto" />
   </theme-config>
 </template>
 
 <script setup lang="ts">
 import Taro from "@tarojs/taro";
+import { ref } from "vue";
 import { Card, ThemeConfig, TitleBar, WList, WListItem } from "@/components";
 import { settingText } from "@/constants/copywriting";
 import { getCopyRight } from "@/utils";
-import { ref } from "vue";
+import SettingCoverImage from "@/assets/photos/setting.svg";
+import { Image as TaroImage } from "@tarojs/components";
 import "./index.scss";
 
 const isEmpty = ref(true);

--- a/src/pages/suit/faq/index.vue
+++ b/src/pages/suit/faq/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="借用须知" back-button />
     <scroll-view :scroll-y="true">
       <view :class="style.header">
-        <image src="@/assets/photos/faq.svg" />
+        <taro-image :src="SuitFAQCoverImage" />
       </view>
 
       <view class="flex-column">
@@ -42,6 +42,8 @@ import { useRequest } from "@/hooks";
 import { SuitService } from "@/services";
 import { SuitFaq } from "@/types/Suit";
 import dayjs from "dayjs";
+import { Image as TaroImage } from "@tarojs/components";
+import SuitFAQCoverImage from "@/assets/photos/faq.svg";
 
 const faqList = ref<SuitFaq[]>([]);
 const isEmpty = ref(true);

--- a/src/pages/suit/index.vue
+++ b/src/pages/suit/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="正装借用" back-button />
     <scroll-view :scroll-y="true">
       <view class="header-view">
-        <image src="@/assets/photos/suit.svg" />
+        <taro-image :src="SuitCoverImage" />
         <view class="extra" @tap="showHelp">
           <view class="icon-wrapper">
             <view class="extra-icon iconfont icon-announcement" />
@@ -67,6 +67,8 @@ import {
 import Taro from "@tarojs/taro";
 import { ref } from "vue";
 import { helpText } from "@/constants/copywriting";
+import SuitCoverImage from "@/assets/photos/suit.svg";
+import { Image as TaroImage } from "@tarojs/components";
 
 const showModal = ref(false);
 const showContent = helpText.suit.main;

--- a/src/pages/suit/information/index.vue
+++ b/src/pages/suit/information/index.vue
@@ -3,7 +3,7 @@
     <title-bar title="我的信息" back-button />
     <scroll-view :scroll-y="true">
       <view :class="style.header">
-        <image src="@/assets/photos/suitapply-suitInformation.svg" />
+        <taro-image :src="SuitInformationCoverImage" />
       </view>
 
       <view class="flex-column">
@@ -106,6 +106,8 @@ import { useRequest } from "@/hooks";
 import { SuitService } from "@/services";
 import Taro from "@tarojs/taro";
 import { helpText } from "@/constants/copywriting";
+import { Image as TaroImage } from "@tarojs/components";
+import SuitInformationCoverImage from "@/assets/photos/suitapply-suitInformation.svg";
 
 const helpContent = helpText.suit.information;
 const isShowHelp = ref(false);

--- a/src/pages/suit/myapplication/PreviewCard/index.vue
+++ b/src/pages/suit/myapplication/PreviewCard/index.vue
@@ -58,7 +58,7 @@
               :key="`${source.id}-${item}`"
               :class="styles['img-wrapper']"
             >
-              <image
+              <taro-image
                 :class="styles.image"
                 style="width: 125Px ;height: 200Px"
                 mode="aspectFill"
@@ -115,7 +115,7 @@
               :key="`${source.id}-${item}`"
               :class="styles['img-wrapper']"
             >
-              <image
+              <taro-image
                 :class="styles.image"
                 style="width: 125Px ;height: 200Px"
                 mode="aspectFill"
@@ -170,7 +170,7 @@
               :key="`${source.id}-${item}`"
               :class="styles['img-wrapper']"
             >
-              <image
+              <taro-image
                 :class="styles.image"
                 style="width: 125Px ;height: 200Px"
                 mode="aspectFill"
@@ -208,6 +208,7 @@
 <script setup lang="ts">
 import { SuitApplyRecord } from "@/types/Suit";
 import { computed, ref, toRefs } from "vue";
+import { Image as TaroImage } from "@tarojs/components";
 import { useRequest } from "@/hooks";
 import { SuitService } from "@/services";
 import { WButton } from "@/components";


### PR DESCRIPTION
vue official 插件会给 image 识别成 h5 的 element，比小程序环境下的 image 组件少了一些属性，比如说 `onLoad` 事件。代码中在 `src/pages/lostfound/PreviewCard/index.vue` 这个组件中用到了。

为了避免类型问题，以及减少后续开发的误导性，给所有 `image` 组件替换成 `taro-image`