### PR TITLE
chore: add typecheck to CI workflows

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -42,6 +42,9 @@ jobs:
         run: |
           echo "${{ secrets.ENV_FILE }}" > .env
 
+      - name: Type Check
+        run: pnpm typecheck
+
       - name: Build Taro weapp
         run: pnpm build:weapp
 

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint changed files
         run: pnpx lint-staged --diff="origin/${{ github.base_ref }}"
 
+      - name: Type Check
+        run: pnpm typecheck
+
       - name: Build Taro weapp
         run: pnpm build:weapp
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,19 +10,8 @@ export default zjutjh(
   },
   {
     rules: {
-      "unicorn/filename-case": "warn",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        {
-          args: "all",
-          argsIgnorePattern: "^_",
-          caughtErrors: "all",
-          caughtErrorsIgnorePattern: "^_",
-          destructuredArrayIgnorePattern: "^_",
-          varsIgnorePattern: "^_",
-          ignoreRestSiblings: true
-        }
-      ]
+      // TODO: 历史文件有很多命名不符合新规范， 逐步修改，暂时先 warning
+      "unicorn/filename-case": "warn"
     }
   }
 );

--- a/src/components/Collapse/CollapsePanel.vue
+++ b/src/components/Collapse/CollapsePanel.vue
@@ -33,7 +33,7 @@ import WListItem from "../List/ListItem.vue";
 
 type PropsType = {
   title?: string;
-  defaltActive?: boolean;
+  defaultActive?: boolean;
   maxHeight?: string;
   arrow?: boolean;
   selected?: boolean;
@@ -41,13 +41,13 @@ type PropsType = {
 
 const props = withDefaults(defineProps<PropsType>(), {
   title: undefined,
-  defaltActive: false,
+  defaultActive: false,
   maxHeight: "500px",
   arrow: false,
   selected: false
 });
 
-const isActive = ref(props.defaltActive);
+const isActive = ref(props.defaultActive);
 
 const handleClick = () => {
   isActive.value = !isActive.value;

--- a/src/components/Collapse/CollapsePanel.vue
+++ b/src/components/Collapse/CollapsePanel.vue
@@ -25,13 +25,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, withDefaults } from "vue";
-import WListItem from "../List/ListItem.vue";
 import "./index.scss";
+
+import { ref } from "vue";
+
+import WListItem from "../List/ListItem.vue";
 
 type PropsType = {
   title?: string;
-  defaltActive?: boolean
+  defaltActive?: boolean;
   maxHeight?: string;
   arrow?: boolean;
   selected?: boolean;
@@ -50,5 +52,4 @@ const isActive = ref(props.defaltActive);
 const handleClick = () => {
   isActive.value = !isActive.value;
 };
-
 </script>

--- a/src/components/Collapse/Panel.vue
+++ b/src/components/Collapse/Panel.vue
@@ -23,19 +23,19 @@ import WListItem from "../List/ListItem.vue";
 
 type PropsType = {
   title?: string;
-  defaltActive?: boolean;
+  defaultActive?: boolean;
   maxHeight?: string;
   arrow?: boolean;
 };
 
 const props = withDefaults(defineProps<PropsType>(), {
   title: undefined,
-  defaltActive: false,
+  defaultActive: false,
   maxHeight: "500px",
   arrow: false
 });
 
-const isActive = ref(props.defaltActive);
+const isActive = ref(props.defaultActive);
 
 const handleClick = () => {
   isActive.value = !isActive.value;

--- a/src/components/Collapse/Panel.vue
+++ b/src/components/Collapse/Panel.vue
@@ -7,10 +7,7 @@
     {{ props.title }}
     <slot name="header" />
   </w-list-item>
-  <view
-    class="wjh-collapse-panel-content"
-    :style="{ maxHeight: isActive ? props.maxHeight : `0` }"
-  >
+  <view class="wjh-collapse-panel-content" :style="{ maxHeight: isActive ? props.maxHeight : `0` }">
     <w-list-item>
       <slot />
     </w-list-item>
@@ -18,16 +15,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref, withDefaults } from "vue";
-import WListItem from "../List/ListItem.vue";
 import "./index.scss";
 
-  type PropsType = {
-    title?: string;
-    defaltActive?: boolean
-    maxHeight?: string;
-    arrow?: boolean
-  };
+import { ref } from "vue";
+
+import WListItem from "../List/ListItem.vue";
+
+type PropsType = {
+  title?: string;
+  defaltActive?: boolean;
+  maxHeight?: string;
+  arrow?: boolean;
+};
 
 const props = withDefaults(defineProps<PropsType>(), {
   title: undefined,
@@ -41,5 +40,4 @@ const isActive = ref(props.defaltActive);
 const handleClick = () => {
   isActive.value = !isActive.value;
 };
-
 </script>

--- a/src/components/Collapse/index.scss
+++ b/src/components/Collapse/index.scss
@@ -1,5 +1,3 @@
-@import "@/style/theme.scss";
-
 .wjh-collapse {
   overflow: hidden;
   color: var(--wjh-color-text);
@@ -29,6 +27,4 @@
     transition: all 0.5s;
     max-height: 500Px;
   }
-
 }
-

--- a/src/components/Descriptions/Descriptions.vue
+++ b/src/components/Descriptions/Descriptions.vue
@@ -10,16 +10,14 @@
 </template>
 
 <script setup lang="ts">
-import { withDefaults } from "vue";
 import "./index.scss";
 
 type PropsType = {
   size?: "small" | "middle";
-  title?: string
+  title?: string;
 };
 const props = withDefaults(defineProps<PropsType>(), {
   size: "middle",
   title: undefined
 });
-
 </script>

--- a/src/components/Descriptions/DescriptionsItem.vue
+++ b/src/components/Descriptions/DescriptionsItem.vue
@@ -10,11 +10,7 @@
       >
         {{ props.label }}
       </view>
-      <view
-        :class="`wjh-descriptions-item-content wjh-col-${
-          24 - props.labelSpan
-        }`"
-      >
+      <view :class="`wjh-descriptions-item-content wjh-col-${24 - props.labelSpan}`">
         <slot />
       </view>
     </view>
@@ -22,16 +18,14 @@
 </template>
 
 <script setup lang="ts">
-import { withDefaults } from "vue";
 import "./index.scss";
 
 type PropsType = {
-  label: string,
-  labelSpan?: number
+  label: string;
+  labelSpan?: number;
 };
 
 const props = withDefaults(defineProps<PropsType>(), {
   labelSpan: 6
 });
-
 </script>

--- a/src/components/List/List.vue
+++ b/src/components/List/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <view :class="['wjh-list', `wjh-list-size-${props.size}`, inner && 'wjh-list-inner'] ">
+  <view :class="['wjh-list', `wjh-list-size-${props.size}`, inner && 'wjh-list-inner']">
     <slot name="header" />
     <template v-if="slots.header">
       <view class="wjh-list-header">
@@ -16,12 +16,13 @@
 </template>
 
 <script setup lang="ts">
-import { useSlots, withDefaults } from "vue";
 import "./index.scss";
 
+import { useSlots } from "vue";
+
 type PropsType = {
-  size?: "small" | "middle",
-  inner?: boolean
+  size?: "small" | "middle";
+  inner?: boolean;
 };
 
 const props = withDefaults(defineProps<PropsType>(), {
@@ -30,5 +31,4 @@ const props = withDefaults(defineProps<PropsType>(), {
 });
 
 const slots = useSlots();
-
 </script>

--- a/src/pages/information/index.module.scss
+++ b/src/pages/information/index.module.scss
@@ -1,5 +1,3 @@
-@import "@/style/theme.scss";
-
 .container {
   position: relative;
   z-index: 0;
@@ -24,7 +22,6 @@
 .content {
   white-space: break-spaces;
   font-size: 1rem;
-  color: var(--wjh-color-week);
   color: var(--wjh-color-text);
   line-height: 125%;
   margin: 16Px auto;
@@ -40,13 +37,13 @@
   color: var(--wjh-color-primary);
 }
 
-.publish-time {
+.publishTime {
   text-align: center;
   font-size: 0.85rem;
   color: var(--wjh-color-week);
 }
 
-.img_container {
+.imgContainer {
   width: 100%;
   height: 100%;
   display: flex;
@@ -65,7 +62,7 @@
   align-items: center;
 }
 
-.logo_container {
+.logoContainer {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/information/index.vue
+++ b/src/pages/information/index.vue
@@ -9,7 +9,7 @@
           </view>
         </view>
         <view class="content">
-          {{ information.content.replace(/\\n/g, '\n') }}
+          {{ information.content.replace(/\\n/g, "\n") }}
         </view>
         <view v-if="information.img1" class="img_container">
           <image
@@ -41,9 +41,7 @@
             @tap="() => handlePreviewImages(information.img3)"
           />
         </view>
-        <view v-if="information.link" class="link">
-          点击跳转相关规定
-        </view>
+        <view v-if="information.link" class="link"> 点击跳转相关规定 </view>
         <template #footer>
           <view class="logo_container">
             <image
@@ -52,9 +50,7 @@
               class="logo_fy"
               mode="aspectFit"
             />
-            <view class="x">
-              X
-            </view>
+            <view class="x"> X </view>
             <image
               src="https://api.cnpatrickstar.com/img/15c05a4c-7c2d-4561-9536-80614b7b65b8.jpg"
               alt="logo_jh"
@@ -62,12 +58,8 @@
               mode="aspectFit"
             />
           </view>
-          <view class="publisher">
-            信息来源: {{ information.publisher }}
-          </view>
-          <view class="publish-time">
-            发布时间: {{ timeFormat(information.publish_time) }}
-          </view>
+          <view class="publisher"> 信息来源: {{ information.publisher }} </view>
+          <view class="publish-time"> 发布时间: {{ timeFormat(information.publish_time) }} </view>
         </template>
       </card>
     </scroll-view>
@@ -75,12 +67,14 @@
 </template>
 
 <script setup lang="ts">
-import { Card, ThemeConfig, TitleBar } from "@/components";
-import { serviceStore } from "@/store";
-import { computed, ref } from "vue";
+import "./index.scss";
+
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
-import "./index.scss";
+import { computed, ref } from "vue";
+
+import { Card, ThemeConfig, TitleBar } from "@/components";
+import { serviceStore } from "@/store";
 
 const instance = Taro.getCurrentInstance();
 
@@ -89,20 +83,26 @@ const needFixWidth = ref(false);
 const { informationId } = instance.router?.params as { informationId?: number };
 
 const information = computed(() => {
-  return serviceStore.information.informationList.find((information) => information.id == informationId)!;
+  return serviceStore.information.informationList.find(
+    (information) => information.id == informationId
+  )!;
 });
 
-const imageList = computed(() => [
-  information.value?.img1 || null,
-  information.value?.img2 || null,
-  information.value?.img3 || null
-].filter(item => !!item) as string[]);
+const imageList = computed(
+  () =>
+    [
+      information.value?.img1 || null,
+      information.value?.img2 || null,
+      information.value?.img3 || null
+    ].filter((item) => Boolean(item)) as string[]
+);
 
 const timeFormat = (time: string) => {
   return dayjs(time).format("YYYY年MM月DD日");
 };
 
-const handleLoadFinish = ({ detail: { height, width } }) => {
+const handleLoadFinish = (e: any) => {
+  const { height, width } = e.detail;
   if (height > width) needFixWidth.value = false;
   else needFixWidth.value = true;
 };

--- a/src/pages/information/index.vue
+++ b/src/pages/information/index.vue
@@ -1,7 +1,7 @@
 <template>
   <theme-config>
-    <title-bar title="资讯" back-button />
-    <scroll-view :scroll-y="true">
+    <title-bar title="资讯" :back-button="true" />
+    <scroll-view v-if="information" :scroll-y="true">
       <card class="container">
         <view class="header">
           <view class="title">
@@ -11,34 +11,14 @@
         <view class="content">
           {{ information.content.replace(/\\n/g, "\n") }}
         </view>
-        <view v-if="information.img1" class="img_container">
+        <view v-for="url in imageList" :key="url" class="img_container">
           <image
-            :src="information.img1"
+            :src="url"
             alt="Card Image"
             class="image"
             mode="aspectFit"
             @load="handleLoadFinish"
-            @tap="() => handlePreviewImages(information.img1)"
-          />
-        </view>
-        <view v-if="information.img2" class="img_container">
-          <image
-            :src="information.img2"
-            alt="Card Image"
-            class="image"
-            mode="aspectFit"
-            @load="handleLoadFinish"
-            @tap="() => handlePreviewImages(information.img2)"
-          />
-        </view>
-        <view v-if="information.img3" class="img_container">
-          <image
-            :src="information.img3"
-            alt="Card Image"
-            class="image"
-            mode="aspectFit"
-            @load="handleLoadFinish"
-            @tap="() => handlePreviewImages(information.img3)"
+            @tap="() => handlePreviewImages(url)"
           />
         </view>
         <view v-if="information.link" class="link"> 点击跳转相关规定 </view>
@@ -59,7 +39,7 @@
             />
           </view>
           <view class="publisher"> 信息来源: {{ information.publisher }} </view>
-          <view class="publish-time"> 发布时间: {{ timeFormat(information.publish_time) }} </view>
+          <view class="publish-time"> 发布时间: {{ publishTime }} </view>
         </template>
       </card>
     </scroll-view>
@@ -71,40 +51,32 @@ import "./index.scss";
 
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
+import { compact, get, uniq } from "lodash-es";
 import { computed, ref } from "vue";
 
 import { Card, ThemeConfig, TitleBar } from "@/components";
 import { serviceStore } from "@/store";
 
 const instance = Taro.getCurrentInstance();
-
 const needFixWidth = ref(false);
 
-const { informationId } = instance.router?.params as { informationId?: number };
-
 const information = computed(() => {
-  return serviceStore.information.informationList.find(
-    (information) => information.id == informationId
-  )!;
+  const informationId = Number(get(instance, ["router", "params", "informationId"], ""));
+  return serviceStore.information.informationList.find((info) => info.id == informationId);
 });
 
-const imageList = computed(
-  () =>
-    [
-      information.value?.img1 || null,
-      information.value?.img2 || null,
-      information.value?.img3 || null
-    ].filter((item) => Boolean(item)) as string[]
+const imageList = computed(() =>
+  uniq(compact([information.value?.img1, information.value?.img2, information.value?.img3]))
 );
 
-const timeFormat = (time: string) => {
-  return dayjs(time).format("YYYY年MM月DD日");
-};
+const publishTime = computed(() => {
+  return dayjs(information.value?.publish_time).format("YYYY年MM月DD日");
+});
 
-const handleLoadFinish = (e: any) => {
-  const { height, width } = e.detail;
-  if (height > width) needFixWidth.value = false;
-  else needFixWidth.value = true;
+const handleLoadFinish = (e: unknown) => {
+  const height = Number(get(e, ["detail", "height"])) || 0;
+  const width = Number(get(e, ["detail", "width"])) || 0;
+  needFixWidth.value = height > width;
 };
 
 const handlePreviewImages = (url: string) => {

--- a/src/pages/information/index.vue
+++ b/src/pages/information/index.vue
@@ -2,16 +2,16 @@
   <theme-config>
     <title-bar title="资讯" :back-button="true" />
     <scroll-view v-if="information" :scroll-y="true">
-      <card class="container">
-        <view class="header">
-          <view class="title">
+      <card :class="styles.container">
+        <view :class="styles.header">
+          <view :class="styles.title">
             {{ information.title }}
           </view>
         </view>
-        <view class="content">
+        <view :class="styles.content">
           {{ information.content.replace(/\\n/g, "\n") }}
         </view>
-        <view v-for="url in imageList" :key="url" class="img_container">
+        <view v-for="url in imageList" :key="url" :class="styles.imgContainer">
           <image
             :src="url"
             alt="Card Image"
@@ -21,16 +21,16 @@
             @tap="() => handlePreviewImages(url)"
           />
         </view>
-        <view v-if="information.link" class="link"> 点击跳转相关规定 </view>
+        <view v-if="information.link" :class="styles.link"> 点击跳转相关规定 </view>
         <template #footer>
-          <view class="logo_container">
+          <view :class="styles.logoContainer">
             <image
               src="https://api.cnpatrickstar.com/img/92a63e97-cd3e-411b-b4aa-8e6fad5fbd00.jpg"
               alt="logo_fy"
               class="logo_fy"
               mode="aspectFit"
             />
-            <view class="x"> X </view>
+            <view :class="styles.x"> X </view>
             <image
               src="https://api.cnpatrickstar.com/img/15c05a4c-7c2d-4561-9536-80614b7b65b8.jpg"
               alt="logo_jh"
@@ -38,8 +38,8 @@
               mode="aspectFit"
             />
           </view>
-          <view class="publisher"> 信息来源: {{ information.publisher }} </view>
-          <view class="publish-time"> 发布时间: {{ publishTime }} </view>
+          <view :class="styles.publisher"> 信息来源: {{ information.publisher }} </view>
+          <view :class="styles.publishTime"> 发布时间: {{ publishTime }} </view>
         </template>
       </card>
     </scroll-view>
@@ -47,8 +47,6 @@
 </template>
 
 <script setup lang="ts">
-import "./index.scss";
-
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
 import { compact, get, uniq } from "lodash-es";
@@ -56,6 +54,8 @@ import { computed, ref } from "vue";
 
 import { Card, ThemeConfig, TitleBar } from "@/components";
 import { serviceStore } from "@/store";
+
+import styles from "./index.module.scss";
 
 const instance = Taro.getCurrentInstance();
 const needFixWidth = ref(false);

--- a/src/pages/lostfound/PreviewCard/index.module.scss
+++ b/src/pages/lostfound/PreviewCard/index.module.scss
@@ -1,5 +1,3 @@
-@import "@/style/theme.scss";
-
 .container {
   width: 100%;
   padding: 0 18Px;
@@ -53,7 +51,7 @@
     }
   }
 
-  .img-list {
+  .imgList {
     display: flex;
     overflow-x: auto;
     gap: 6Px;
@@ -73,13 +71,13 @@
       }
     }
 
-    .img-container {
+    .imgContainer {
       flex: 1; // dynamic
       display: flex;
       gap: 16Px;
       width: 100%;
 
-      .img-wrapper {
+      .imgWrapper {
         position: relative;
         flex: 1;
 

--- a/src/pages/lostfound/PreviewCard/index.vue
+++ b/src/pages/lostfound/PreviewCard/index.vue
@@ -38,22 +38,16 @@
           物品介绍 {{ source.introduction }}
         </text>
       </view>
-      <view :class="styles['img-list']">
-        <view
-          :class="[styles['img-container'], imageList.length > 1 ? styles.multiple : undefined]"
-        >
-          <view
-            v-for="item in imageList"
-            :key="`${source.id}-${item}`"
-            :class="styles['img-wrapper']"
-          >
+      <view :class="styles.imgList">
+        <view :class="[styles.imgContainer, imageList.length > 1 && styles.multiple]">
+          <view v-for="url in imageList" :key="`${source.id}-${url}`" :class="styles.imgWrapper">
             <image
               :class="styles.image"
               style="width: 100px; height: 100px"
               mode="aspectFill"
-              :src="item"
+              :src="url"
               @load="handleLoadFinish"
-              @tap="() => handlePreviewImages(item)"
+              @tap="() => handlePreviewImages(url)"
             />
           </view>
         </view>
@@ -77,22 +71,16 @@
           物品介绍 {{ source.introduction }}
         </text>
       </view>
-      <view :class="styles['img-list']">
-        <view
-          :class="[styles['img-container'], imageList.length > 1 ? styles.multiple : undefined]"
-        >
-          <view
-            v-for="item in imageList"
-            :key="`${source.id}-${item}`"
-            :class="styles['img-wrapper']"
-          >
+      <view :class="styles.imgList">
+        <view :class="[styles.imgContainer, imageList.length > 1 ? styles.multiple : undefined]">
+          <view v-for="url in imageList" :key="`${source.id}-${url}`" :class="styles.imgWrapper">
             <image
               :class="styles.image"
               style="width: 100px; height: 100px"
               mode="aspectFill"
-              :src="item"
+              :src="url"
               @load="handleLoadFinish"
-              @tap="() => handlePreviewImages(item)"
+              @tap="() => handlePreviewImages(url)"
             />
           </view>
         </view>

--- a/src/pages/lostfound/PreviewCard/index.vue
+++ b/src/pages/lostfound/PreviewCard/index.vue
@@ -4,7 +4,7 @@
       <view :class="styles.title">
         {{ source.type ? "失物招领" : "寻物启事" }}
       </view>
-      <view v-if="isForyou" :class="styles.joint">
+      <view v-if="isForYou" :class="styles.joint">
         <image
           src="https://api.cnpatrickstar.com/img/92a63e97-cd3e-411b-b4aa-8e6fad5fbd00.jpg"
           alt="logo_fy"
@@ -100,7 +100,7 @@
     </view>
     <view :class="styles.footer" class="flex-column">
       <text>业务服务: {{ source.publisher }}</text>
-      <text>发布时间: {{ timeFormat(source.publish_time) }}</text>
+      <text>发布时间: {{ publishTime }}</text>
     </view>
   </view>
 </template>
@@ -108,30 +108,25 @@
 <script setup lang="ts">
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
-import { computed, ref, toRefs } from "vue";
+import { compact, get, uniq } from "lodash-es";
+import { computed, ref } from "vue";
 
 import { LostfoundRecord } from "@/types/Lostfound";
 
 import styles from "./index.module.scss";
 
-const props = defineProps<{
+interface PreviewCardProps {
   source: LostfoundRecord;
-}>();
+}
+
+const props = defineProps<PreviewCardProps>();
 const needFixWidth = ref(false);
 
-const imageList = computed(
-  () =>
-    [source.value?.img1 || null, source.value?.img2 || null, source.value?.img3 || null].filter(
-      (item) => Boolean(item)
-    ) as string[]
+const imageList = computed(() =>
+  uniq(compact([props.source.img1, props.source.img2, props.source.img3]))
 );
 
-const { source } = toRefs(props);
-
-const isForyou = ref(false);
-if (source.value.publisher.slice(0, 4) === "“For") {
-  isForyou.value = true;
-}
+const isForYou = computed(() => props.source.publisher.slice(0, 4) === "“For");
 
 const handlePreviewImages = (url: string) => {
   Taro.previewImage({
@@ -140,13 +135,11 @@ const handlePreviewImages = (url: string) => {
   });
 };
 
-const handleLoadFinish = (e: any) => {
-  const { height, width } = e.detail;
-  if (height > width) needFixWidth.value = false;
-  else needFixWidth.value = true;
+const handleLoadFinish = (e: unknown) => {
+  const height = Number(get(e, ["detail", "height"])) || 0;
+  const width = Number(get(e, ["detail", "width"])) || 0;
+  needFixWidth.value = height > width;
 };
 
-const timeFormat = (time: string) => {
-  return dayjs(time).format("YYYY年MM月DD日");
-};
+const publishTime = computed(() => dayjs(props.source.publish_time).format("YYYY年MM月DD日"));
 </script>

--- a/src/pages/lostfound/PreviewCard/index.vue
+++ b/src/pages/lostfound/PreviewCard/index.vue
@@ -1,13 +1,8 @@
 <template>
-  <view
-    :class="[
-      styles.container,
-      source.type ? styles.lost : styles.found
-    ]"
-  >
+  <view :class="[styles.container, source.type ? styles.lost : styles.found]">
     <view :class="styles.header">
       <view :class="styles.title">
-        {{ source.type ? "失物招领": "寻物启事" }}
+        {{ source.type ? "失物招领" : "寻物启事" }}
       </view>
       <view v-if="isForyou" :class="styles.joint">
         <image
@@ -27,48 +22,25 @@
     </view>
     <view v-if="!source.type" :class="styles.body">
       <view :class="styles.content" class="flex-column">
-        <text
-          v-show="source.item_name"
-          space="emsp"
-          :class="styles.text"
-        >
-          物体名称  {{ source.item_name }}
+        <text v-show="source.item_name" space="emsp" :class="styles.text">
+          物体名称 {{ source.item_name }}
         </text>
-        <text
-          v-show="source.lost_or_found_place"
-          space="emsp"
-          :class="styles.text"
-        >
-          遗失地点  {{ source.lost_or_found_place }}
+        <text v-show="source.lost_or_found_place" space="emsp" :class="styles.text">
+          遗失地点 {{ source.lost_or_found_place }}
         </text>
-        <text
-          v-show="source.lost_or_found_time"
-          space="emsp"
-          :class="styles.text"
-        >
-          遗失时间  {{ source.lost_or_found_time }}
+        <text v-show="source.lost_or_found_time" space="emsp" :class="styles.text">
+          遗失时间 {{ source.lost_or_found_time }}
         </text>
-        <text
-          v-show="source.contact"
-          space="emsp"
-          :class="styles.text"
-        >
-          联系方式  {{ source.contact }}
+        <text v-show="source.contact" space="emsp" :class="styles.text">
+          联系方式 {{ source.contact }}
         </text>
-        <text
-          v-show="source.introduction"
-          space="emsp"
-          :class="styles.text"
-        >
-          物品介绍  {{ source.introduction }}
+        <text v-show="source.introduction" space="emsp" :class="styles.text">
+          物品介绍 {{ source.introduction }}
         </text>
       </view>
       <view :class="styles['img-list']">
         <view
-          :class="[
-            styles['img-container'],
-            imageList.length > 1 ? styles.multiple : undefined
-          ]"
+          :class="[styles['img-container'], imageList.length > 1 ? styles.multiple : undefined]"
         >
           <view
             v-for="item in imageList"
@@ -77,7 +49,7 @@
           >
             <image
               :class="styles.image"
-              style="width: 100Px ;height: 100Px"
+              style="width: 100px; height: 100px"
               mode="aspectFill"
               :src="item"
               @load="handleLoadFinish"
@@ -89,48 +61,25 @@
     </view>
     <view v-else-if="source.type" :class="styles.body">
       <view :class="styles.content" class="flex-column">
-        <text
-          v-show="source.item_name"
-          space="emsp"
-          :class="styles.text"
-        >
-          物体名称  {{ source.item_name }}
+        <text v-show="source.item_name" space="emsp" :class="styles.text">
+          物体名称 {{ source.item_name }}
         </text>
-        <text
-          v-show="source.lost_or_found_place"
-          space="emsp"
-          :class="styles.text"
-        >
-          拾得地点  {{ source.lost_or_found_place }}
+        <text v-show="source.lost_or_found_place" space="emsp" :class="styles.text">
+          拾得地点 {{ source.lost_or_found_place }}
         </text>
-        <text
-          v-show="source.lost_or_found_time"
-          space="emsp"
-          :class="styles.text"
-        >
-          拾得时间  {{ source.lost_or_found_time }}
+        <text v-show="source.lost_or_found_time" space="emsp" :class="styles.text">
+          拾得时间 {{ source.lost_or_found_time }}
         </text>
-        <text
-          v-show="source.pickup_place"
-          space="emsp"
-          :class="styles.text"
-        >
-          领取地点  {{ source.pickup_place }}
+        <text v-show="source.pickup_place" space="emsp" :class="styles.text">
+          领取地点 {{ source.pickup_place }}
         </text>
-        <text
-          v-show="source.introduction"
-          space="emsp"
-          :class="styles.text"
-        >
-          物品介绍  {{ source.introduction }}
+        <text v-show="source.introduction" space="emsp" :class="styles.text">
+          物品介绍 {{ source.introduction }}
         </text>
       </view>
       <view :class="styles['img-list']">
         <view
-          :class="[
-            styles['img-container'],
-            imageList.length > 1 ? styles.multiple : undefined
-          ]"
+          :class="[styles['img-container'], imageList.length > 1 ? styles.multiple : undefined]"
         >
           <view
             v-for="item in imageList"
@@ -139,7 +88,7 @@
           >
             <image
               :class="styles.image"
-              style="width: 100Px ;height: 100Px"
+              style="width: 100px; height: 100px"
               mode="aspectFill"
               :src="item"
               @load="handleLoadFinish"
@@ -157,10 +106,12 @@
 </template>
 
 <script setup lang="ts">
-import { LostfoundRecord } from "@/types/Lostfound";
-import { computed, ref, toRefs } from "vue";
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
+import { computed, ref, toRefs } from "vue";
+
+import { LostfoundRecord } from "@/types/Lostfound";
+
 import styles from "./index.module.scss";
 
 const props = defineProps<{
@@ -168,11 +119,12 @@ const props = defineProps<{
 }>();
 const needFixWidth = ref(false);
 
-const imageList = computed(() => [
-  source.value?.img1 || null,
-  source.value?.img2 || null,
-  source.value?.img3 || null
-].filter(item => !!item) as string[]);
+const imageList = computed(
+  () =>
+    [source.value?.img1 || null, source.value?.img2 || null, source.value?.img3 || null].filter(
+      (item) => Boolean(item)
+    ) as string[]
+);
 
 const { source } = toRefs(props);
 
@@ -188,7 +140,8 @@ const handlePreviewImages = (url: string) => {
   });
 };
 
-const handleLoadFinish = ({ detail: { height, width } }) => {
+const handleLoadFinish = (e: any) => {
+  const { height, width } = e.detail;
   if (height > width) needFixWidth.value = false;
   else needFixWidth.value = true;
 };

--- a/src/pages/suit/myapplication/PreviewCard/Modal/index.vue
+++ b/src/pages/suit/myapplication/PreviewCard/Modal/index.vue
@@ -13,7 +13,7 @@
         <slot name="footer" />
       </view>
       <view v-if="actions" class="actions">
-        <view style="display: flex; text-align: center;">
+        <view style="display: flex; text-align: center">
           <view class="button" @tap="handleCancel">
             <text>{{ actions?.cancel.label }}</text>
           </view>
@@ -23,17 +23,14 @@
         </view>
       </view>
     </view>
-    <view
-      v-if="props.mask"
-      class="wjh-modal-mask"
-      @tap="closeModal"
-    />
+    <view v-if="props.mask" class="wjh-modal-mask" @tap="closeModal" />
   </view>
 </template>
 
 <script setup lang="ts">
-import { useSlots, withDefaults } from "vue";
 import "./index.scss";
+
+import { useSlots } from "vue";
 
 type PropsType = {
   title?: string;
@@ -44,12 +41,12 @@ type PropsType = {
     cancel: {
       label: string;
       callback?: () => void;
-    },
+    };
     confirm: {
       label: string;
       callback?: () => void;
-    }
-  }
+    };
+  };
 };
 
 const props = withDefaults(defineProps<PropsType>(), {
@@ -75,5 +72,4 @@ const handleCancel = () => {
 const closeModal = () => {
   emit("update:show", false);
 };
-
 </script>

--- a/src/pages/suit/myapplication/PreviewCard/index.module.scss
+++ b/src/pages/suit/myapplication/PreviewCard/index.module.scss
@@ -1,5 +1,3 @@
-@import "@/style/theme.scss";
-
 .container {
   width: 100%;
   padding: 0 18Px;
@@ -23,7 +21,8 @@
     font-size: 1.1rem;
     line-height: 100%;
   }
-  .icon-box {
+
+  .iconBox {
     display: flex;
     border-radius: 8Px;
     color: var(--wjh-color-orange-600);
@@ -33,7 +32,8 @@
     margin-left: auto;
     align-items: center;
   }
-  .time{
+
+  .time {
     font-size: 0.8rem;
     line-height: 80%;
     margin-left: auto;
@@ -43,15 +43,17 @@
 .body {
   border-bottom: 2Px solid var(--wjh-color-border);
 
-  .flex-container{
+  .flexContainer {
     padding: 50px 0;
     display: flex;
+
     .content {
       max-width: 30%;
       padding: 6Px 0;
       white-space: pre-wrap;
       margin-left: auto;
       gap: 1.5rem;
+
       .text {
         margin-top: -20px;
         text-indent: -4em;
@@ -59,19 +61,20 @@
       }
     }
 
-    .img-list {
+    .imgList {
       display: flex;
       overflow-x: auto;
       gap: 6Px;
       padding-bottom: 6Px;
       margin-right: auto;
-      .img-container {
+
+      .imgContainer {
         flex: 1; // dynamic
         display: flex;
         gap: 16Px;
         width: 100%;
 
-        .img-wrapper {
+        .imgWrapper {
           position: relative;
 
           .image {
@@ -87,7 +90,7 @@
 }
 
 .loan {
-  .header{
+  .header {
     color: var(--wjh-color-green-700);
   }
 }
@@ -104,12 +107,12 @@
   }
 }
 
-.button{
+.button {
   margin-left: auto;
   width: 200px;
   font-size: 0.9rem;
 }
 
-.wjh-modal-body{
+.wjh-modal-body {
   min-height: auto !important;
 }

--- a/src/pages/suit/myapplication/PreviewCard/index.vue
+++ b/src/pages/suit/myapplication/PreviewCard/index.vue
@@ -176,6 +176,7 @@
 <script setup lang="ts">
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
+import { get } from "lodash-es";
 import { computed, ref, toRefs } from "vue";
 
 import { WButton } from "@/components";
@@ -191,13 +192,9 @@ const props = defineProps<{
 }>();
 const isShowConfirm = ref(false);
 const needFixWidth = ref(false);
-const imageList = computed(
-  () =>
-    [
-      source.value?.img ||
-        "https://api.cnpatrickstar.com/img/b57036a9-c17c-41af-9e5d-893af1aa7d9a.jpg"
-    ].filter((item) => Boolean(item)) as string[]
-);
+const imageList = computed(() => [
+  source.value.img || "https://api.cnpatrickstar.com/img/b57036a9-c17c-41af-9e5d-893af1aa7d9a.jpg"
+]);
 const { source } = toRefs(props);
 const emit = defineEmits(["isDelete"]);
 
@@ -218,8 +215,8 @@ const { run } = useRequest(SuitService.deleteRecords, {
 });
 
 const isOverTime = computed(() => {
-  const agotime = dayjs().subtract(7, "day");
-  return dayjs(source.value.borrow_time).isBefore(agotime);
+  const agoTime = dayjs().subtract(7, "day");
+  return dayjs(source.value.borrow_time).isBefore(agoTime);
 });
 
 const handlePreviewImages = (url: string) => {
@@ -242,10 +239,10 @@ const onConfirm = () => {
   run();
 };
 
-const handleLoadFinish = (e: any) => {
-  const { height, width } = e.detail;
-  if (height > width) needFixWidth.value = false;
-  else needFixWidth.value = true;
+const handleLoadFinish = (e: unknown) => {
+  const height = Number(get(e, ["detail", "height"])) || 0;
+  const width = Number(get(e, ["detail", "width"])) || 0;
+  needFixWidth.value = height > width;
 };
 
 const timeFormat = (time: string) => {

--- a/src/pages/suit/myapplication/PreviewCard/index.vue
+++ b/src/pages/suit/myapplication/PreviewCard/index.vue
@@ -11,7 +11,7 @@
   >
     <view v-if="source.status === 1 || source.status === 2" :class="styles.header">
       <view :class="styles.title"> 我的申请 </view>
-      <view v-show="source.status == 2" :class="styles['icon-box']">
+      <view v-show="source.status == 2" :class="styles.iconBox">
         <icon type="warn" color="#f0ad3e" size="15" />
         <view class="desc">
           <text>被驳回</text>
@@ -23,7 +23,7 @@
     </view>
     <view v-if="source.status === 3" :class="styles.header">
       <view :class="styles.title"> 我的申请 </view>
-      <view v-show="isOverTime" :class="styles['icon-box']">
+      <view v-show="isOverTime" :class="styles.iconBox">
         <icon type="warn" color="#f0ad3e" size="15" />
         <view class="desc">
           <text>超时</text>
@@ -36,13 +36,13 @@
       <text :class="styles.time"> 归还时间:{{ timeFormat(source.return_time) }} </text>
     </view>
     <view v-if="source.status === 1 || source.status === 2" :class="styles.body">
-      <view :class="styles['flex-container']" style="display: flex">
-        <view :class="styles['img-list']">
-          <view :class="[styles['img-container']]">
+      <view :class="styles.flexContainer" style="display: flex">
+        <view :class="styles.imgList">
+          <view :class="[styles.imgContainer]">
             <view
               v-for="item in imageList"
               :key="`${source.id}-${item}`"
-              :class="styles['img-wrapper']"
+              :class="styles.imgWrapper"
             >
               <image
                 :class="styles.image"
@@ -89,13 +89,13 @@
       </view>
     </view>
     <view v-if="source.status === 3" :class="styles.body">
-      <view :class="styles['flex-container']">
-        <view :class="styles['img-list']">
-          <view :class="[styles['img-container']]">
+      <view :class="styles.flexContainer">
+        <view :class="styles.imgList">
+          <view :class="[styles.imgContainer]">
             <view
               v-for="item in imageList"
               :key="`${source.id}-${item}`"
-              :class="styles['img-wrapper']"
+              :class="styles.imgWrapper"
             >
               <image
                 :class="styles.image"
@@ -132,13 +132,13 @@
       </view>
     </view>
     <view v-if="source.status === 4" :class="styles.body">
-      <view :class="styles['flex-container']">
-        <view :class="styles['img-list']">
-          <view :class="[styles['img-container']]">
+      <view :class="styles.flexContainer">
+        <view :class="styles.imgList">
+          <view :class="[styles.imgContainer]">
             <view
               v-for="item in imageList"
               :key="`${source.id}-${item}`"
-              :class="styles['img-wrapper']"
+              :class="styles.imgWrapper"
             >
               <image
                 :class="styles.image"

--- a/src/pages/suit/myapplication/PreviewCard/index.vue
+++ b/src/pages/suit/myapplication/PreviewCard/index.vue
@@ -4,16 +4,13 @@
       styles.container,
       source.status === 1 || source.status === 2
         ? styles.pend
-        : (source.status === 3 ? styles.loan : styles.complete)
+        : source.status === 3
+          ? styles.loan
+          : styles.complete
     ]"
   >
-    <view
-      v-if="source.status === 1 || source.status === 2"
-      :class="styles.header"
-    >
-      <view :class="styles.title">
-        我的申请
-      </view>
+    <view v-if="source.status === 1 || source.status === 2" :class="styles.header">
+      <view :class="styles.title"> 我的申请 </view>
       <view v-show="source.status == 2" :class="styles['icon-box']">
         <icon type="warn" color="#f0ad3e" size="15" />
         <view class="desc">
@@ -25,32 +22,21 @@
       </text>
     </view>
     <view v-if="source.status === 3" :class="styles.header">
-      <view :class="styles.title">
-        我的申请
-      </view>
+      <view :class="styles.title"> 我的申请 </view>
       <view v-show="isOverTime" :class="styles['icon-box']">
         <icon type="warn" color="#f0ad3e" size="15" />
         <view class="desc">
           <text>超时</text>
         </view>
       </view>
-      <text :class="styles.time">
-        借用时间:{{ timeFormat(source.borrow_time) }}
-      </text>
+      <text :class="styles.time"> 借用时间:{{ timeFormat(source.borrow_time) }} </text>
     </view>
     <view v-if="source.status === 4" :class="styles.header">
-      <view :class="styles.title">
-        我的申请
-      </view>
-      <text :class="styles.time">
-        归还时间:{{ timeFormat(source.return_time) }}
-      </text>
+      <view :class="styles.title"> 我的申请 </view>
+      <text :class="styles.time"> 归还时间:{{ timeFormat(source.return_time) }} </text>
     </view>
     <view v-if="source.status === 1 || source.status === 2" :class="styles.body">
-      <view
-        :class="styles['flex-container']"
-        style="display: flex;"
-      >
+      <view :class="styles['flex-container']" style="display: flex">
         <view :class="styles['img-list']">
           <view :class="[styles['img-container']]">
             <view
@@ -60,7 +46,7 @@
             >
               <image
                 :class="styles.image"
-                style="width: 125Px ;height: 200Px"
+                style="width: 125px; height: 200px"
                 mode="aspectFill"
                 :src="item"
                 @load="handleLoadFinish"
@@ -70,24 +56,20 @@
           </view>
         </view>
         <view :class="styles.content" class="flex-column">
-          <text v-show="source.id" space="emsp" :class="styles.text">
-            ID  {{ source.id }}
-          </text>
+          <text v-show="source.id" space="emsp" :class="styles.text"> ID {{ source.id }} </text>
           <text v-show="source.kind" space="emsp" :class="styles.text">
-            类别  {{ source.kind }}
+            类别 {{ source.kind }}
           </text>
           <text v-show="source.name" space="emsp" :class="styles.text">
-            名称  {{ source.name }}
+            名称 {{ source.name }}
           </text>
           <text v-show="source.spec" space="emsp" :class="styles.text">
-            规格  {{ source.spec }}
+            规格 {{ source.spec }}
           </text>
           <text v-show="source.count" space="emsp" :class="styles.text">
-            数量  {{ source.count }}
+            数量 {{ source.count }}
           </text>
-          <w-button :class="styles.button" @tap="handleClick">
-            取消申请
-          </w-button>
+          <w-button :class="styles.button" @tap="handleClick"> 取消申请 </w-button>
           <modal
             v-model:show="isShowConfirm"
             title="提示"
@@ -117,7 +99,7 @@
             >
               <image
                 :class="styles.image"
-                style="width: 125Px ;height: 200Px"
+                style="width: 125px; height: 200px"
                 mode="aspectFill"
                 :src="item"
                 @load="handleLoadFinish"
@@ -127,36 +109,24 @@
           </view>
         </view>
         <view :class="styles.content" class="flex-column">
-          <text v-show="source.id" space="emsp" :class="styles.text">
-            ID  {{ source.id }}
-          </text>
+          <text v-show="source.id" space="emsp" :class="styles.text"> ID {{ source.id }} </text>
           <text v-show="source.kind" space="emsp" :class="styles.text">
-            类别  {{ source.kind }}
+            类别 {{ source.kind }}
           </text>
           <text v-show="source.name" space="emsp" :class="styles.text">
-            名称  {{ source.name }}
+            名称 {{ source.name }}
           </text>
           <text v-show="source.spec" space="emsp" :class="styles.text">
-            规格  {{ source.spec }}
+            规格 {{ source.spec }}
           </text>
           <text v-show="source.count" space="emsp" :class="styles.text">
-            数量  {{ source.count }}
+            数量 {{ source.count }}
           </text>
-          <text
-            v-if="!isOverTime"
-            v-show="source.borrow_time"
-            space="emsp"
-            :class="styles.text"
-          >
-            剩余时间  {{ timeCount(source.borrow_time) }}
+          <text v-if="!isOverTime" v-show="source.borrow_time" space="emsp" :class="styles.text">
+            剩余时间 {{ timeCount(source.borrow_time) }}
           </text>
-          <text
-            v-if="isOverTime"
-            v-show="source.borrow_time"
-            space="emsp"
-            :class="styles.text"
-          >
-            超时时间  {{ timeCount(source.borrow_time) }}
+          <text v-if="isOverTime" v-show="source.borrow_time" space="emsp" :class="styles.text">
+            超时时间 {{ timeCount(source.borrow_time) }}
           </text>
         </view>
       </view>
@@ -172,7 +142,7 @@
             >
               <image
                 :class="styles.image"
-                style="width: 125Px ;height: 200Px"
+                style="width: 125px; height: 200px"
                 mode="aspectFill"
                 :src="item"
                 @load="handleLoadFinish"
@@ -182,23 +152,21 @@
           </view>
         </view>
         <view :class="styles.content" class="flex-column">
-          <text v-show="source.id" space="emsp" :class="styles.text">
-            ID  {{ source.id }}
-          </text>
+          <text v-show="source.id" space="emsp" :class="styles.text"> ID {{ source.id }} </text>
           <text v-show="source.kind" space="emsp" :class="styles.text">
-            类别  {{ source.kind }}
+            类别 {{ source.kind }}
           </text>
           <text v-show="source.name" space="emsp" :class="styles.text">
-            名称  {{ source.name }}
+            名称 {{ source.name }}
           </text>
           <text v-show="source.spec" space="emsp" :class="styles.text">
-            规格  {{ source.spec }}
+            规格 {{ source.spec }}
           </text>
           <text v-show="source.count" space="emsp" :class="styles.text">
-            数量  {{ source.count }}
+            数量 {{ source.count }}
           </text>
           <text v-show="source.return_time" space="emsp" :class="styles.text">
-            借用时长  {{ timeDuring(source.borrow_time ,source.return_time) }}
+            借用时长 {{ timeDuring(source.borrow_time, source.return_time) }}
           </text>
         </view>
       </view>
@@ -206,44 +174,48 @@
   </view>
 </template>
 <script setup lang="ts">
-import { SuitApplyRecord } from "@/types/Suit";
-import { computed, ref, toRefs } from "vue";
-import { useRequest } from "@/hooks";
-import { SuitService } from "@/services";
-import { WButton } from "@/components";
-import Modal from "./Modal/index.vue";
 import Taro from "@tarojs/taro";
 import dayjs from "dayjs";
+import { computed, ref, toRefs } from "vue";
+
+import { WButton } from "@/components";
+import { useRequest } from "@/hooks";
+import { SuitService } from "@/services";
+import { SuitApplyRecord } from "@/types/Suit";
+
 import styles from "./index.module.scss";
+import Modal from "./Modal/index.vue";
 
 const props = defineProps<{
   source: SuitApplyRecord;
 }>();
 const isShowConfirm = ref(false);
 const needFixWidth = ref(false);
-const imageList = computed(() => [
-  source.value?.img || "https://api.cnpatrickstar.com/img/b57036a9-c17c-41af-9e5d-893af1aa7d9a.jpg"
-].filter(item => !!item) as string[]);
+const imageList = computed(
+  () =>
+    [
+      source.value?.img ||
+        "https://api.cnpatrickstar.com/img/b57036a9-c17c-41af-9e5d-893af1aa7d9a.jpg"
+    ].filter((item) => Boolean(item)) as string[]
+);
 const { source } = toRefs(props);
 const emit = defineEmits(["isDelete"]);
 
-const { run } = useRequest(
-  SuitService.deleteRecords, {
-    defaultParams: {
-      borrow_id: source.value.id
-    },
-    loadingDelay: 60,
-    manual: true,
-    onSuccess: (res) => {
-      if (res.data.code === 1) {
-        emit("isDelete", "true");
-      } else throw new Error(res.data.msg);
-    },
-    onError: (e: Error) => {
-      return `加载申请信息失败\r\n${e.message || "网络错误"}`;
-    }
+const { run } = useRequest(SuitService.deleteRecords, {
+  defaultParams: {
+    borrow_id: source.value.id
+  },
+  loadingDelay: 60,
+  manual: true,
+  onSuccess: (res) => {
+    if (res.data.code === 1) {
+      emit("isDelete", "true");
+    } else throw new Error(res.data.msg);
+  },
+  onError: (e: Error) => {
+    return `加载申请信息失败\r\n${e.message || "网络错误"}`;
   }
-);
+});
 
 const isOverTime = computed(() => {
   const agotime = dayjs().subtract(7, "day");
@@ -270,7 +242,8 @@ const onConfirm = () => {
   run();
 };
 
-const handleLoadFinish = ({ detail: { height, width } }) => {
+const handleLoadFinish = (e: any) => {
+  const { height, width } = e.detail;
   if (height > width) needFixWidth.value = false;
   else needFixWidth.value = true;
 };
@@ -280,27 +253,25 @@ const timeFormat = (time: string) => {
 };
 
 const timeCount = (borrow_time: string) => {
-  let secondDuring = (dayjs(borrow_time).add(7, "day").unix()) - (dayjs().unix());
+  let secondDuring = dayjs(borrow_time).add(7, "day").unix() - dayjs().unix();
   if (isOverTime.value == true) {
-    secondDuring = (dayjs().unix()) - (dayjs(borrow_time).add(7, "day").unix());
+    secondDuring = dayjs().unix() - dayjs(borrow_time).add(7, "day").unix();
   }
-  const setHours = Math.floor(secondDuring / 60 / 60 % 24);
+  const setHours = Math.floor((secondDuring / 60 / 60) % 24);
   const setDay = Math.floor(secondDuring / 60 / 60 / 24);
   if (Math.abs(setDay) > 0) {
-    return setDay + "天\t";
-  } else {
-    return setHours + "小时\t";
+    return `${setDay}天\t`;
   }
+  return `${setHours}小时\t`;
 };
 
 const timeDuring = (borrow_time: string, return_time: string) => {
-  const secondDuring = (dayjs(return_time).unix() - dayjs(borrow_time).unix());
-  const setHours = Math.floor(secondDuring / 60 / 60 % 24);
+  const secondDuring = dayjs(return_time).unix() - dayjs(borrow_time).unix();
+  const setHours = Math.floor((secondDuring / 60 / 60) % 24);
   const setDay = Math.floor(secondDuring / 60 / 60 / 24);
   if (Math.abs(setDay) > 0) {
-    return setDay + "天\t";
-  } else {
-    return setHours + "小时\t";
+    return `${setDay}天\t`;
   }
+  return `${setHours}小时\t`;
 };
 </script>

--- a/src/pages/suit/myapplication/index.module.scss
+++ b/src/pages/suit/myapplication/index.module.scss
@@ -1,6 +1,4 @@
-@import "@/style/theme.scss";
-
-.campus-selector {
+.campusSelector {
   background-color: var(--wjh-color-background-container);
   padding: 12Px;
 
@@ -30,13 +28,13 @@
   }
 }
 
-.kind-selector {
+.kindSelector {
   display: flex;
   font-size: 1.1rem;
   color: var(--wjh-color-week);
   background-color: var(--wjh-color-primary-light);
 
-  .scroll-view {
+  .scrollView {
     margin-top: -9px;
     font-size: 0.9em;
     display: flex;
@@ -61,6 +59,6 @@
   }
 }
 
-.record-list {
+.recordList {
   padding: 16Px;
 }

--- a/src/pages/suit/myapplication/index.vue
+++ b/src/pages/suit/myapplication/index.vue
@@ -1,6 +1,6 @@
 <template>
   <theme-config>
-    <title-bar title="我的申请" back-button />
+    <title-bar title="我的申请" :back-button="true" />
     <view :class="styles['campus-selector']">
       <view :class="styles['container']">
         <view
@@ -35,7 +35,7 @@
           @is-delete="needRefresh"
         />
         <w-skeleton v-if="loading" :style="{ borderRadius: '8Px' }" />
-        <card v-else-if="!recordList.length" is-empty>
+        <card v-else-if="!recordList.length" :is-empty="true">
           <text>该分类下暂无申请记录</text>
         </card>
       </view>
@@ -72,7 +72,8 @@ const { loading, run } = useRequest(SuitService.getRecords, {
   loadingDelay: 600,
   onSuccess: (res) => {
     if (res.data.code === 1) {
-      recordList.value = recordList.value?.concat(
+      recordList.value = recordList.value.concat(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Array.isArray(res.data.data) ? res.data.data : (res.data.data as any).data || []
       );
       if (recordList.value.length === 0) isEmpty.value = true;
@@ -83,9 +84,9 @@ const { loading, run } = useRequest(SuitService.getRecords, {
   }
 });
 
-const getRecords = (data: { campus?: number; status?: number }) => {
+const getRecords = (data: Parameters<typeof SuitService.getRecords>[0]) => {
   isEmpty.value = false;
-  run(data as any);
+  run(data);
 };
 
 const handleSelectCampus = (campus: string) => {
@@ -98,6 +99,7 @@ const handleSelectCampus = (campus: string) => {
     status: statusChange[selectStatus.value]
   });
 };
+
 const handleSelectStatus = (status: string) => {
   if (selectStatus.value === status) return;
   selectStatus.value = status;

--- a/src/pages/suit/myapplication/index.vue
+++ b/src/pages/suit/myapplication/index.vue
@@ -13,11 +13,9 @@
         </view>
       </view>
     </view>
-    <view :class="[styles['kind-selector'],'flex-column']">
+    <view :class="[styles['kind-selector'], 'flex-column']">
       <view :class="styles['scroll-view']">
-        <text>
-          状态  |
-        </text>
+        <text> 状态 | </text>
         <text
           v-for="item in statusList"
           :key="item"
@@ -28,11 +26,7 @@
         </text>
       </view>
     </view>
-    <scroll-view
-      lower-threshold="100"
-      :scroll-y="true"
-      :class="styles['list-wrapper']"
-    >
+    <scroll-view lower-threshold="100" :scroll-y="true" :class="styles['list-wrapper']">
       <view :class="styles['record-list']">
         <preview-card
           v-for="record in recordList"
@@ -50,15 +44,16 @@
 </template>
 
 <script setup lang="ts">
-import styles from "./index.module.scss";
-import { ThemeConfig, TitleBar, Card, WSkeleton } from "@/components";
 import { ref } from "vue";
+
+import { Card, ThemeConfig, TitleBar, WSkeleton } from "@/components";
 import { useRequest } from "@/hooks";
 import { SuitService } from "@/services";
-import { SuitApplyRecord } from "@/types/Suit";
-import PreviewCard from "./PreviewCard/index.vue";
-import { omit } from "lodash-es";
 import store, { serviceStore } from "@/store";
+import { SuitApplyRecord } from "@/types/Suit";
+
+import styles from "./index.module.scss";
+import PreviewCard from "./PreviewCard/index.vue";
 
 const recordList = ref<SuitApplyRecord[]>([]);
 const campusList = ref<string[]>(["屏峰", "朝晖", "莫干山"]);
@@ -66,35 +61,31 @@ const statusList = ref<string[]>(["待处理", "借用中", "已完成"]);
 const selectCampus = ref(serviceStore.suit.lastOpenCampus || "朝晖");
 const selectStatus = ref(serviceStore.suit.lastOpenStatus || "待处理");
 const isEmpty = ref(false);
-const campusChange = { "朝晖": 1, "屏峰": 2, "莫干山": 3 }, statusChange = { "待处理": 1, "借用中": 3, "已完成": 4 };
+const campusChange = { 朝晖: 1, 屏峰: 2, 莫干山: 3 },
+  statusChange = { 待处理: 1, 借用中: 3, 已完成: 4 };
 
-const { loading, run } = useRequest(
-  SuitService.getRecords, {
-    defaultParams: {
-      campus: campusChange[selectCampus.value],
-      status: statusChange[selectStatus.value]
-    },
-    loadingDelay: 600,
-    onSuccess: (res) => {
-      if (res.data.code === 1) {
-        recordList.value = recordList.value?.concat(
-          res.data.data
-        );
-        if (recordList.value.length === 0) isEmpty.value = true;
-      } else throw new Error(res.data.msg);
-    },
-    onError: (e: Error) => {
-      return `加载申请信息失败\r\n${e.message || "网络错误"}`;
-    }
+const { loading, run } = useRequest(SuitService.getRecords, {
+  defaultParams: {
+    campus: campusChange[selectCampus.value],
+    status: statusChange[selectStatus.value]
+  },
+  loadingDelay: 600,
+  onSuccess: (res) => {
+    if (res.data.code === 1) {
+      recordList.value = recordList.value?.concat(
+        Array.isArray(res.data.data) ? res.data.data : (res.data.data as any).data || []
+      );
+      if (recordList.value.length === 0) isEmpty.value = true;
+    } else throw new Error(res.data.msg);
+  },
+  onError: (e: Error) => {
+    return `加载申请信息失败\r\n${e.message || "网络错误"}`;
   }
-);
+});
 
-const getRecords = (data: {
-  campus?: string;
-  status?: string;
-}) => {
+const getRecords = (data: { campus?: number; status?: number }) => {
   isEmpty.value = false;
-  run(omit(data, [data.status === "待处理" ? "kind" : null]));
+  run(data as any);
 };
 
 const handleSelectCampus = (campus: string) => {

--- a/src/pages/suit/myapplication/index.vue
+++ b/src/pages/suit/myapplication/index.vue
@@ -1,33 +1,33 @@
 <template>
   <theme-config>
     <title-bar title="我的申请" :back-button="true" />
-    <view :class="styles['campus-selector']">
-      <view :class="styles['container']">
+    <view :class="styles.campusSelector">
+      <view :class="styles.container">
         <view
           v-for="item in campusList"
           :key="item"
-          :class="[styles['campus'], selectCampus === item ? styles['active'] : undefined]"
+          :class="[styles.campus, selectCampus === item ? styles.active : undefined]"
           @tap="() => handleSelectCampus(item)"
         >
           <text>{{ item }}</text>
         </view>
       </view>
     </view>
-    <view :class="[styles['kind-selector'], 'flex-column']">
-      <view :class="styles['scroll-view']">
+    <view :class="[styles.kindSelector, 'flex-column']">
+      <view :class="styles.scrollView">
         <text> 状态 | </text>
         <text
           v-for="item in statusList"
           :key="item"
-          :class="selectStatus === item ? styles['active'] : undefined"
+          :class="selectStatus === item ? styles.active : undefined"
           @tap="() => handleSelectStatus(item)"
         >
           {{ item }}
         </text>
       </view>
     </view>
-    <scroll-view lower-threshold="100" :scroll-y="true" :class="styles['list-wrapper']">
-      <view :class="styles['record-list']">
+    <scroll-view lower-threshold="100" :scroll-y="true" :class="styles.listWrapper">
+      <view :class="styles.recordList">
         <preview-card
           v-for="record in recordList"
           :key="record.id"


### PR DESCRIPTION
## 背景

为 CI 加上 typecheck，并顺手修掉已有的类型错误、清理 lint 问题、把几个页面迁到 css module。

## 改动范围

- **CI**：`check-master.yml` / `check-pr.yml` 增加 `pnpm typecheck` 步骤
- **ESLint**：删掉 `@typescript-eslint/no-unused-vars` 的重复规则（假设基础配置 `@zjutjh/eslint-config` 已包含）
- **通用组件类型修复**：`Collapse/*`、`Descriptions/*`、`List/List.vue`（顺带修 `defaltActive` typo）
- **页面改动**：`information/`、`lostfound/PreviewCard/`、`suit/myapplication/` 类型修复 + css module 迁移

## 需要验证的点

> 都是改动过程中有疑问或者可能有副作用的地方，合并前走查一下

- [ ] **`suit/myapplication/index.vue` 的 `onSuccess` fallback**：`Array.isArray(res.data.data) ? ... : (res.data.data as any).data || []`。`suitService.getRecords` 声明的返回类型是 `{ data: SuitApplyRecord[] }`，这个 fallback 和类型声明不符。需要确认后端是否真的会返回嵌套结构 — 是的话修类型声明，不是的话删掉 fallback
- [ ] **`handleLoadFinish` 的事件类型**：`information`、`lostfound/PreviewCard`、`suit/myapplication/PreviewCard` 三处都改成了 `(e: unknown) => ... lodash.get(e, ["detail", "height"])`，丢了类型。可以换成 Taro 的 `CommonEventFunction<onLoadEventDetail>`。顺带确认一下：`needFixWidth` 在这几个文件里只写不读，是不是可以连同 `handleLoadFinish` 一起删
- [ ] **inline style `Px` → `px`**：`lostfound/PreviewCard` 和 `suit/myapplication/PreviewCard` 里模板的 `100Px` / `125Px` 改成了小写。`config/index.ts` 里 `htmltransform.enable: false`，理论上不会被转 rpx，但 codebase 约定是 `Px`，建议改回保持一致
- [ ] **ESLint `no-unused-vars` 规则**：删掉了 `argsIgnorePattern: "^_"` 等自定义配置。需要确认 `@zjutjh/eslint-config` 里已经有等价配置，否则 `_` 前缀忽略未使用变量的惯例会失效
- [ ] **`suit/myapplication/index.vue` 删掉了 `omit` 逻辑**：原来在"待处理"状态下会剔除 `kind` 字段。由于调用方未传 `kind`，当前是 no-op，删了不影响行为，但记一下这层意图

## 顺便做的重构（行为应保持一致，但值得扫一眼）

- `lostfound/PreviewCard` 的 `isForyou` 从 `ref + 初始化 if` 改为 `computed`（修了 `source` 变化时不重算的响应性 bug）
- `information` 三个 `<image>` 合并为 `v-for` + `uniq(compact([img1, img2, img3]))`
- Vue 3.4+ `withDefaults` 不需要显式 import，清理了几处